### PR TITLE
0.4.0

### DIFF
--- a/.github/workflows/relup-ci.yml
+++ b/.github/workflows/relup-ci.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         ./scripts/check_versions ${{vars.RELNAME}} $(/usr/bin/git log -1 --format='%H') > vsn.log
         cat vsn.log
-        cat vsn.log | awk '/Generated appup/ { appup=1 }
+        cat vsn.log | awk '/Generated appup/ || /Compiling .*\.appup\.src/ { appup=1 }
                            /relup successfully created!/ { relup=1 }
                            END { if (!appup) { print "appup missing"; exit 1}
                                  if (!relup) { print "relup missing"; exit 1} }'

--- a/apps/pixelwar/src/pixelwar.app.src
+++ b/apps/pixelwar/src/pixelwar.app.src
@@ -1,6 +1,6 @@
 {application, pixelwar, [
     {description, "An OTP application"},
-    {vsn, "0.3.0"},
+    {vsn, "0.4.0"},
     {registered, []},
     {mod, {pixelwar_app, []}},
     {applications, [

--- a/apps/pixelwar/src/pixelwar.appup.src
+++ b/apps/pixelwar/src/pixelwar.appup.src
@@ -1,12 +1,8 @@
 {"0.4.0", % New version
  [{"0.3.0", [
-    {remove_application, cowboy},
-    {restart_application, pixelwar},
-    {add_application, cowboy}
+    {restart_application, pixelwar}
     ]}],
  [{"0.3.0", [
-    {remove_application, cowboy},
-    {restart_application, pixelwar},
-    {add_application, cowboy}
+    {restart_application, pixelwar}
     ]}]
 }.

--- a/apps/pixelwar/src/pixelwar.appup.src
+++ b/apps/pixelwar/src/pixelwar.appup.src
@@ -1,4 +1,12 @@
 {"0.4.0", % New version
- [{"0.3.0", [{restart_application, pixelwar}]}],
- [{"0.3.0", [{restart_application, pixelwar}]}]
+ [{"0.3.0", [
+    {remove_application, cowboy},
+    {restart_application, pixelwar},
+    {add_application, cowboy}
+    ]}],
+ [{"0.3.0", [
+    {remove_application, cowboy},
+    {restart_application, pixelwar},
+    {add_application, cowboy}
+    ]}]
 }.

--- a/apps/pixelwar/src/pixelwar.appup.src
+++ b/apps/pixelwar/src/pixelwar.appup.src
@@ -1,0 +1,4 @@
+{"0.4.0", % New version
+ [{"0.3.0", [{restart_application, pixelwar}]}],
+ [{"0.3.0", [{restart_application, pixelwar}]}]
+}.

--- a/apps/pixelwar/src/pixelwar.appup.src
+++ b/apps/pixelwar/src/pixelwar.appup.src
@@ -1,4 +1,10 @@
 {"0.4.0", % New version
- [{"0.3.0", [{restart_application, pixelwar}]}],
- [{"0.3.0", [{restart_application, pixelwar}]}]
+ [{"0.3.0", [
+    {remove_application, pixelwar},
+    {add_application, pixelwar}
+    ]}],
+ [{"0.3.0", [
+    {remove_application, pixelwar},
+    {add_application, pixelwar}
+    ]}]
 }.

--- a/apps/pixelwar/src/pixelwar.appup.src
+++ b/apps/pixelwar/src/pixelwar.appup.src
@@ -1,10 +1,4 @@
 {"0.4.0", % New version
- [{"0.3.0", [
-    {remove_application, pixelwar},
-    {add_application, pixelwar}
-    ]}],
- [{"0.3.0", [
-    {remove_application, pixelwar},
-    {add_application, pixelwar}
-    ]}]
+ [{"0.3.0", [{restart_application, pixelwar}]}],
+ [{"0.3.0", [{restart_application, pixelwar}]}]
 }.

--- a/apps/pixelwar/src/pixelwar.appup.src
+++ b/apps/pixelwar/src/pixelwar.appup.src
@@ -1,8 +1,16 @@
 {"0.4.0", % New version
  [{"0.3.0", [
-    {restart_application, pixelwar}
+    {restart_application, pixelwar},
+    {update, pixelwar_app},
+    {update, pixelwar_sup},
+    {update, pixelwar_matrix_serv},
+    {update, pixelwar_pixel_handler}
     ]}],
  [{"0.3.0", [
-    {restart_application, pixelwar}
+    {restart_application, pixelwar},
+    {update, pixelwar_app},
+    {update, pixelwar_sup},
+    {update, pixelwar_matrix_serv},
+    {update, pixelwar_pixel_handler}
     ]}]
 }.

--- a/apps/pixelwar/src/pixelwar_app.erl
+++ b/apps/pixelwar/src/pixelwar_app.erl
@@ -14,7 +14,7 @@ start(_StartType, _StartArgs) ->
         {'_', [{"/:room", pixelwar_pixel_handler, []}]}
     ]),
     persistent_term:put(pixelwar_dispatch, Dispatch),
-    {ok, _} = cowboy:start_clear(
+    cowboy:start_clear(
         my_http_listener,
         [{port, 8080}],
         #{env => #{dispatch => {persistent_term, pixelwar_dispatch}}}

--- a/apps/pixelwar/src/pixelwar_app.erl
+++ b/apps/pixelwar/src/pixelwar_app.erl
@@ -7,7 +7,7 @@
 
 -behaviour(application).
 
--export([start/2, prep_stop/1, stop/1]).
+-export([start/2, stop/1]).
 
 start(_StartType, _StartArgs) ->
     Dispatch = cowboy_router:compile([
@@ -22,9 +22,5 @@ start(_StartType, _StartArgs) ->
     
     pixelwar_sup:start_link().
 
-prep_stop(State) ->
-    ok = application:stop(cowboy),
-    State.
-
 stop(_State) ->
-    ok.
+    ok = application:stop(cowboy).

--- a/apps/pixelwar/src/pixelwar_app.erl
+++ b/apps/pixelwar/src/pixelwar_app.erl
@@ -23,7 +23,7 @@ start(_StartType, _StartArgs) ->
     pixelwar_sup:start_link().
 
 prep_stop(State) ->
-    ok = cowboy:stop_listener(my_http_listener),
+    ok = application:stop(cowboy),
     State.
 
 stop(_State) ->

--- a/apps/pixelwar/src/pixelwar_app.erl
+++ b/apps/pixelwar/src/pixelwar_app.erl
@@ -23,4 +23,5 @@ start(_StartType, _StartArgs) ->
     pixelwar_sup:start_link().
 
 stop(_State) ->
+    ok = cowboy:stop_listener(my_http_listener),
     ok.

--- a/apps/pixelwar/src/pixelwar_app.erl
+++ b/apps/pixelwar/src/pixelwar_app.erl
@@ -23,4 +23,4 @@ start(_StartType, _StartArgs) ->
     pixelwar_sup:start_link().
 
 stop(_State) ->
-    ok = application:stop(cowboy).
+    ok.

--- a/apps/pixelwar/src/pixelwar_app.erl
+++ b/apps/pixelwar/src/pixelwar_app.erl
@@ -11,13 +11,15 @@
 
 start(_StartType, _StartArgs) ->
     Dispatch = cowboy_router:compile([
-        {'_', [{"/pixel", pixelwar_pixel_handler, []}]}
+        {'_', [{"/:room", pixelwar_pixel_handler, []}]}
     ]),
+    persistent_term:put(pixelwar_dispatch, Dispatch),
     {ok, _} = cowboy:start_clear(
         my_http_listener,
         [{port, 8080}],
-        #{env => #{dispatch => Dispatch}}
+        #{env => #{dispatch => {persistent_term, pixelwar_dispatch}}}
     ),
+    
     pixelwar_sup:start_link().
 
 stop(_State) ->

--- a/apps/pixelwar/src/pixelwar_app.erl
+++ b/apps/pixelwar/src/pixelwar_app.erl
@@ -7,7 +7,7 @@
 
 -behaviour(application).
 
--export([start/2, stop/1]).
+-export([start/2, prep_stop/1, stop/1]).
 
 start(_StartType, _StartArgs) ->
     Dispatch = cowboy_router:compile([
@@ -22,6 +22,9 @@ start(_StartType, _StartArgs) ->
     
     pixelwar_sup:start_link().
 
-stop(_State) ->
+prep_stop(State) ->
     ok = cowboy:stop_listener(my_http_listener),
+    State.
+
+stop(_State) ->
     ok.

--- a/apps/pixelwar/src/pixelwar_matrix_serv.erl
+++ b/apps/pixelwar/src/pixelwar_matrix_serv.erl
@@ -1,5 +1,5 @@
 -module(pixelwar_matrix_serv).
--vsn("0.3.0").
+-vsn("0.4.0").
 -behaviour(gen_server).
 -include_lib("matrix.hrl").
 
@@ -55,15 +55,6 @@ terminate(normal, _State) ->
 
 terminate(_Reason, _State) ->
     ok.
-
-code_change("0.2.0", State, _Extra) ->
-    {_, Pixels, Width, Height} = State,
-    {ok, Matrix} = pixelwar_matrix:create(Width, Height, Pixels),
-    {ok, #state{matrix = Matrix}};
-
-code_change({down, "0.2.0"}, State, _Extra) ->
-    {_, {_, Pixels, Width, Height}} = State,
-    {ok, {state, Pixels, Width, Height}};
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.

--- a/apps/pixelwar/src/pixelwar_matrix_serv.erl
+++ b/apps/pixelwar/src/pixelwar_matrix_serv.erl
@@ -8,17 +8,19 @@
 }).
 
 %% API
--export([start_link/0, set_element/2, get_state/1]).
+-export([start_link/1, set_element/2, get_state/1, stop/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
 
-start_link() ->
-    gen_server:start_link({local, matrix}, ?MODULE, [], []).
+start_link(ChannelName) ->
+    gen_server:start_link({global, ChannelName}, ?MODULE, [], []).
 
-set_element(Instance, Pixel) ->
-    gen_server:cast(Instance, {set_element, Pixel}).
+set_element(ChannelName, Pixel) ->
+    gen_server:cast({global, ChannelName}, {set_element, Pixel}).
 
-get_state(Instance) ->
-    gen_server:call(Instance, get_state).
+get_state(ChannelName) ->
+    gen_server:call({global, ChannelName}, get_state).
+
+stop(ChannelName) -> gen_server:call({global, ChannelName}, stop).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -49,6 +51,9 @@ handle_cast(_Msg, State) ->
 
 handle_info(_Info, State) ->
     {noreply, State}.
+
+terminate(normal, _State) ->
+    ok;
 
 terminate(_Reason, _State) ->
     ok.

--- a/apps/pixelwar/src/pixelwar_matrix_serv.erl
+++ b/apps/pixelwar/src/pixelwar_matrix_serv.erl
@@ -8,19 +8,17 @@
 }).
 
 %% API
--export([start_link/1, set_element/2, get_state/1, stop/1]).
+-export([start_link/1, set_element/2, get_state/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
 
-start_link(ChannelName) ->
-    gen_server:start_link({global, ChannelName}, ?MODULE, [], []).
+start_link(ServerName) ->
+    gen_server:start_link({global, ServerName}, ?MODULE, [], []).
 
-set_element(ChannelName, Pixel) ->
-    gen_server:cast({global, ChannelName}, {set_element, Pixel}).
+set_element(ServerName, Pixel) ->
+    gen_server:cast({global, ServerName}, {set_element, Pixel}).
 
-get_state(ChannelName) ->
-    gen_server:call({global, ChannelName}, get_state).
-
-stop(ChannelName) -> gen_server:call({global, ChannelName}, stop).
+get_state(ServerName) ->
+    gen_server:call({global, ServerName}, get_state).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -29,7 +27,7 @@ init(_Args) ->
     {ok, #state{matrix = Matrix}}.
 
 handle_call(stop, _From, State) ->
-    {stop, normal, stopped, State};
+    {stop, normal, State};
 
 handle_call(get_state, _From, State) ->
     Binary = pixelwar_matrix:to_binary(State#state.matrix),

--- a/apps/pixelwar/src/pixelwar_pixel_handler.erl
+++ b/apps/pixelwar/src/pixelwar_pixel_handler.erl
@@ -3,20 +3,20 @@
 -export([init/2, websocket_init/1, websocket_handle/2, websocket_info/2]).
 
 -record(state, {
-    channel_name :: binary
+    server_name :: binary
 }).
 
 init(Req, _State) ->
-    ChannelName = cowboy_req:binding(room, Req),
-    pixelwar_sup:add_matrix(ChannelName),
-    {cowboy_websocket, Req, #state{channel_name=ChannelName}}.
+    ServerName = cowboy_req:binding(room, Req),
+    pixelwar_sup:add_matrix(ServerName),
+    {cowboy_websocket, Req, #state{server_name=ServerName}}.
 
 websocket_init(State) ->
-    gproc:reg({p, l, State#state.channel_name}),
+    gproc:ensure_reg({p, l, State#state.server_name}),
     {ok, State}.
 
 websocket_handle({binary, <<_:8>>}, State) ->
-    MatrixState = pixelwar_matrix_serv:get_state(State#state.channel_name),
+    MatrixState = pixelwar_matrix_serv:get_state(State#state.server_name),
     {reply, [{binary, MatrixState}], State};
 websocket_handle(
     {binary,
@@ -24,14 +24,14 @@ websocket_handle(
             Color:1/little-unsigned-integer-unit:16>> = Data},
     State
 ) ->
-    pixelwar_matrix_serv:set_element(State#state.channel_name, {X, Y, Color}),
-    gproc:send({p, l, State#state.channel_name}, {self(), State#state.channel_name, Data}),
+    pixelwar_matrix_serv:set_element(State#state.server_name, {X, Y, Color}),
+    gproc:send({p, l, State#state.server_name}, {self(), State#state.server_name, Data}),
     {ok, State}.
 
-websocket_info({From, Room, Event}, State) when Room =:= State#state.channel_name ->
+websocket_info({From, Room, Event}, State) when Room =:= State#state.server_name ->
     if
         From =:= self() -> {ok, State};
         true -> {reply, [{binary, Event}], State}
     end;
 websocket_info(_Info, State) ->
-    {stop, State}.
+    {ok, State}.

--- a/apps/pixelwar/src/pixelwar_pixel_handler.erl
+++ b/apps/pixelwar/src/pixelwar_pixel_handler.erl
@@ -2,15 +2,21 @@
 
 -export([init/2, websocket_init/1, websocket_handle/2, websocket_info/2]).
 
-init(Req0, State) ->
-    {cowboy_websocket, Req0, State}.
+-record(state, {
+    channel_name :: binary
+}).
+
+init(Req, _State) ->
+    ChannelName = cowboy_req:binding(room, Req),
+    pixelwar_sup:add_matrix(ChannelName),
+    {cowboy_websocket, Req, #state{channel_name=ChannelName}}.
 
 websocket_init(State) ->
-    gproc:reg({p, l, my_room}),
+    gproc:reg({p, l, State#state.channel_name}),
     {ok, State}.
 
 websocket_handle({binary, <<_:8>>}, State) ->
-    MatrixState = pixelwar_matrix_serv:get_state(matrix),
+    MatrixState = pixelwar_matrix_serv:get_state(State#state.channel_name),
     {reply, [{binary, MatrixState}], State};
 websocket_handle(
     {binary,
@@ -18,11 +24,11 @@ websocket_handle(
             Color:1/little-unsigned-integer-unit:16>> = Data},
     State
 ) ->
-    pixelwar_matrix_serv:set_element(matrix, {X, Y, Color}),
-    gproc:send({p, l, my_room}, {self(), my_room, Data}),
+    pixelwar_matrix_serv:set_element(State#state.channel_name, {X, Y, Color}),
+    gproc:send({p, l, State#state.channel_name}, {self(), State#state.channel_name, Data}),
     {ok, State}.
 
-websocket_info({From, my_room, Event}, State) ->
+websocket_info({From, Room, Event}, State) when Room =:= State#state.channel_name ->
     if
         From =:= self() -> {ok, State};
         true -> {reply, [{binary, Event}], State}

--- a/apps/pixelwar/src/pixelwar_sup.erl
+++ b/apps/pixelwar/src/pixelwar_sup.erl
@@ -1,30 +1,30 @@
 -module(pixelwar_sup).
 
 -behaviour(supervisor).
-%% API
--export([start_link/0]).
+-export([start_link/0, add_matrix/1]).
 -export([init/1]).
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
+add_matrix(ChannelName) ->
+    supervisor:start_child(?MODULE, [ChannelName]).
+
 init(_Args) ->
     SupervisorSpecification = #{
-        % one_for_one | one_for_all | rest_for_one | simple_one_for_one
-        strategy => one_for_one,
+        strategy => simple_one_for_one,
         intensity => 10,
         period => 60
     },
 
     ChildSpecifications = [
         #{
-            id => matrix,
+            id => pixelwar_matrix_serv,
             start => {pixelwar_matrix_serv, start_link, []},
-            % permanent | transient | temporary
-            restart => permanent,
+            restart => transient,
             shutdown => 2000,
-            % worker | supervisor
-            type => worker
+            type => worker,
+            modules => [pixelwar_matrix_serv]
         }
     ],
 

--- a/apps/pixelwar/test/pixelwar_serv_SUITE.erl
+++ b/apps/pixelwar/test/pixelwar_serv_SUITE.erl
@@ -3,6 +3,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("apps/pixelwar/src/matrix.hrl").
 -compile(export_all).
+-define(SERVER_NAME, "matrix").
 
 all() ->
     [get_state_test_case, place_out_of_bounds_test_case].
@@ -11,6 +12,9 @@ init_per_testcase(_Case, Config) ->
     application:load(pixelwar),
 
     {ok, Apps} = application:ensure_all_started([pixelwar]),
+
+    pixelwar_sup:add_matrix(?SERVER_NAME),
+
     [{apps, Apps} | Config].
 
 end_per_testcase(_Case, Config) ->
@@ -24,11 +28,11 @@ get_state_test_case() ->
     ].
 
 get_state_test_case(_Config) ->
-    pixelwar_matrix_serv:set_element(matrix, {42, 42, 12}),
-    pixelwar_matrix_serv:set_element(matrix, {42, 42, 42}),
-    pixelwar_matrix_serv:set_element(matrix, {11, 12, 13}),
+    pixelwar_matrix_serv:set_element(?SERVER_NAME, {42, 42, 12}),
+    pixelwar_matrix_serv:set_element(?SERVER_NAME, {42, 42, 42}),
+    pixelwar_matrix_serv:set_element(?SERVER_NAME, {11, 12, 13}),
 
-    MatrixAsBin = pixelwar_matrix_serv:get_state(matrix),
+    MatrixAsBin = pixelwar_matrix_serv:get_state(?SERVER_NAME),
     ?assertEqual(
         MatrixAsBin,
         <<11:16/little, 12:16/little, 13:16/little, 42:16/little, 42:16/little, 42:16/little>>
@@ -39,10 +43,10 @@ place_out_of_bounds_test_case(_) ->
     Outbound = ?DEFAULT_SIZE + 2,
 
     % In bounds
-    pixelwar_matrix_serv:set_element(matrix, {Inbound, Inbound, 13}),
+    pixelwar_matrix_serv:set_element(?SERVER_NAME, {Inbound, Inbound, 13}),
     % Out of bounds
-    pixelwar_matrix_serv:set_element(matrix, {Outbound + 2, Outbound + 2, 13}),
+    pixelwar_matrix_serv:set_element(?SERVER_NAME, {Outbound + 2, Outbound + 2, 13}),
 
-    MatrixAsBin = pixelwar_matrix_serv:get_state(matrix),
+    MatrixAsBin = pixelwar_matrix_serv:get_state(?SERVER_NAME),
 
     ?assertEqual(MatrixAsBin, <<Inbound:16/little, Inbound:16/little, 13:16/little>>).

--- a/apps/pixelwar/test/pixelwar_ws_SUITE.erl
+++ b/apps/pixelwar/test/pixelwar_ws_SUITE.erl
@@ -11,6 +11,9 @@ init_per_testcase(_Case, Config) ->
 
     application:load(gun),
     {ok, Apps} = application:ensure_all_started([pixelwar, gun]),
+    
+    pixelwar_sup:add_matrix("matrix"),
+    
     [{apps, Apps} | Config].
 
 end_per_testcase(_Case, Config) ->

--- a/rebar.config
+++ b/rebar.config
@@ -39,7 +39,7 @@
 ]}.
 
 {relx, [
-    {release, {pixelwar, "0.3.0"}, [
+    {release, {pixelwar, "0.4.0"}, [
         pixelwar,
         sasl
     ]},

--- a/test/upgrade_downgrade_SUITE.erl
+++ b/test/upgrade_downgrade_SUITE.erl
@@ -69,6 +69,8 @@ upgrade_case(Config) ->
 after_upgrade_case(Config) ->
     Peer = ?config(peer, Config),
 
+    pixelwar_sup:add_matrix(?SERVER_NAME),
+
     MatrixAsBin = peer:call(Peer, pixelwar_matrix_serv, get_state, [?SERVER_NAME]),
     ?assertEqual(
         MatrixAsBin,

--- a/test/upgrade_downgrade_SUITE.erl
+++ b/test/upgrade_downgrade_SUITE.erl
@@ -2,6 +2,7 @@
 -behaviour(ct_suite).
 -export([all/0, groups/0]).
 -compile(export_all).
+-define(SERVER_NAME, "matrix").
 
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -68,21 +69,21 @@ upgrade_case(Config) ->
 after_upgrade_case(Config) ->
     Peer = ?config(peer, Config),
 
-    MatrixAsBin = peer:call(Peer, pixelwar_matrix_serv, get_state, [matrix]),
+    MatrixAsBin = peer:call(Peer, pixelwar_matrix_serv, get_state, [?SERVER_NAME]),
     ?assertEqual(
         MatrixAsBin,
-        <<12:16/little, 12:16/little, 12:16/little, 112:16/little, 112:16/little, 112:16/little>>
+        <<>>
     ).
 
 before_downgrade_case(Config) ->
     Peer = ?config(peer, Config),
 
-    peer:call(Peer, pixelwar_matrix_serv, set_element, [matrix, {13, 13, 13}]),
+    peer:call(Peer, pixelwar_matrix_serv, set_element, [?SERVER_NAME, {13, 13, 13}]),
     
-    MatrixAsBin = peer:call(Peer, pixelwar_matrix_serv, get_state, [matrix]),
+    MatrixAsBin = peer:call(Peer, pixelwar_matrix_serv, get_state, [?SERVER_NAME]),
     ?assertEqual(
         MatrixAsBin,
-        <<12:16/little, 12:16/little, 12:16/little, 13:16/little, 13:16/little, 13:16/little, 112:16/little, 112:16/little, 112:16/little>>
+        <<13:16/little, 13:16/little, 13:16/little>>
     ).
 
 downgrade_case(Config) ->
@@ -101,7 +102,7 @@ after_downgrade_case(Config) ->
     MatrixAsBin = peer:call(Peer, pixelwar_matrix_serv, get_state, [matrix]),
     ?assertEqual(
         MatrixAsBin,
-        <<12:16/little, 12:16/little, 12:16/little, 13:16/little, 13:16/little, 13:16/little, 112:16/little, 112:16/little, 112:16/little>>
+        <<>>
     ).
 
 % ========== HELPERS ==========


### PR DESCRIPTION
- `/:room` should create a new `pixelwar_matrix_server`.
- `pixelwar_matrix_server` should be destroyed after some inactivity time.
- Upgrade should be possible
    - Kill old server